### PR TITLE
Fix compatibility issue with afuse (SSHFS automounter)

### DIFF
--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -152,13 +152,13 @@ def get_settings(view, name, default=None):
 
     plugin_settings = sublime.load_settings('Anaconda.sublime-settings')
 
-    if (name in ('python_interpreter', 'extra_paths')
-            and not ENVIRON_HOOK_INVALID[view.id()]):
+    if (name in ('python_interpreter', 'extra_paths') and
+            not ENVIRON_HOOK_INVALID[view.id()]):
         if view.window() is not None and view.window().folders():
             dirname = view.window().folders()[0]
             while True:
                 environfile = os.path.join(dirname, '.anaconda')
-                if os.path.exists(environfile):
+                if os.path.isfile(environfile):
                     # print("Environ found on %s" % environfile)
                     with open(environfile, 'r') as jsonfile:
                         try:


### PR DESCRIPTION
Anaconda crashes when opening a file located on a remote server accessed through [afuse](https://github.com/pcarrier/afuse) (a SSHFS helper).

This is caused the way afuse manages the directory where SSHFS mount points are stored. In this particular directory, `if os.path.exists(environfile)` will always return `True`, resulting in a `.anaconda` file trying to be opened. This operation will fail with an `OSError` exception being thrown as shown in the following traceback:

```
Traceback (most recent call last):
  File "/usr/local/sublime-text-3/sublime_plugin.py", line 304, in on_activated
    callback.on_activated(v)
  File "/home/oyaji/.config/sublime-text-3/Packages/Anaconda/listeners/linting.py", line 118, in on_activated
    self.run_linter(view)
  File "/home/oyaji/.config/sublime-text-3/Packages/Anaconda/anaconda_lib/linting/sublime.py", line 344, in run_linter
    Worker().execute(Callback(on_success=parse_results), **data)
  File "/home/oyaji/.config/sublime-text-3/Packages/Anaconda/anaconda_lib/worker.py", line 438, in execute
    worker.start()
  File "/home/oyaji/.config/sublime-text-3/Packages/Anaconda/anaconda_lib/worker.py", line 161, in start
    active_view(), 'python_interpreter')
  File "/home/oyaji/.config/sublime-text-3/Packages/Anaconda/anaconda_lib/helpers.py", line 163, in get_settings
    with open(environfile, 'r') as jsonfile:
OSError: [Errno 6] No such device or address: '/home/oyaji/sshfs-mnt/.anaconda'
```

Substituting `os.path.exists` with `os.path.isfile` solves this issue since the "file" is a mount-point and not a real file.
